### PR TITLE
fix: remove unused artifact_hash field from memories (#116)

### DIFF
--- a/src/modules/tools/memory.py
+++ b/src/modules/tools/memory.py
@@ -665,7 +665,7 @@ def mem0_store(
         mem0_store(content="[FINDING] XSS Vulnerability confirmed on /contactus endpoint with name parameter. - Technique: stored_xss",
             metadata={"category": "finding", "severity": "HIGH",
                       "status": "verified", "validation_status": "verified",
-                      "technique": "stored_xss", "artifact_hash": "sha256_of_artifact"})
+                      "technique": "stored_xss"})
 
         # Store observation during reconnaissance
         mem0_store(content="[OBSERVATION] Discovered 15 endpoints, JWT auth, admin panel at /admin returns 403",


### PR DESCRIPTION
This PR removes the artifact_hash field from the mem0_store tool documentation and ensures it is no longer referenced in the codebase.
Removed artifact_hash from the mem0_store docstring example in src/modules/tools/memory.py.
Verified that no other references exist in the documentation (docs/) or prompt templates (src/modules/prompts/templates/).
Fixes #116