### PR TITLE
Add bug bounty marker headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -666,6 +666,22 @@ The unified structure organizes all artifacts under operation-specific directori
 - `--output-dir`: Custom output directory (default: ./outputs)
 - `--mcp-enabled`: Enable MCP tools
 - `--mcp-conns`: Provide JSON of MCP server, the same `mcp.connections` block present in the configuration file 
+- `--bug-bounty-header NAME=VALUE`: Add an HTTP marker header for authorized bug bounty traffic (repeatable)
+- `--bug-bounty-headers-json '{...}'`: Add marker headers from a JSON object
+
+### Bug Bounty Traffic Markers
+
+Some programs require every request to include researcher marker headers such as `X-HackerOne-Research`, `X-Bugcrowd`, or a custom `User-Agent`. Configure them at startup:
+
+```bash
+python src/cyberautoagent.py \
+  --target "https://example.com" \
+  --objective "Authorized bug bounty testing" \
+  --bug-bounty-header X-HackerOne-Research=username \
+  --bug-bounty-header User-Agent=username@wearehackerone.com
+```
+
+The agent pre-applies these headers to browser traffic and adds them to tool guidance so `http_request`, shell tools, and MCP tools include the same markers.
 
 ### Usage Examples
 

--- a/README.md
+++ b/README.md
@@ -667,7 +667,6 @@ The unified structure organizes all artifacts under operation-specific directori
 - `--mcp-enabled`: Enable MCP tools
 - `--mcp-conns`: Provide JSON of MCP server, the same `mcp.connections` block present in the configuration file 
 - `--bug-bounty-header NAME=VALUE`: Add an HTTP marker header for authorized bug bounty traffic (repeatable)
-- `--bug-bounty-headers-json '{...}'`: Add marker headers from a JSON object
 
 ### Bug Bounty Traffic Markers
 

--- a/docs/user-instructions.md
+++ b/docs/user-instructions.md
@@ -194,6 +194,29 @@ cyber-react \
 | `--deployment-mode`    | Auto      | local-cli, single-container, full-stack |
 | `--mcp-enabled`        | `false`   | Enable MCP Tools                        |
 | `--mcp-conns` '[...]'  | None      | Configure MCP Tools                     |
+| `--bug-bounty-header NAME=VALUE` | None | Add a marker header to authorized bug bounty traffic; repeat for multiple headers |
+| `--bug-bounty-headers-json '{...}'` | None | Add marker headers from a JSON object |
+
+### Bug Bounty Traffic Markers
+
+Some programs require marker headers on every request. Configure them once so the agent applies them to the shared browser context and includes them in prompts for HTTP/MCP/tool usage:
+
+```bash
+cyber-react \
+  --target "https://example.com" \
+  --objective "Authorized bug bounty testing" \
+  --bug-bounty-header X-HackerOne-Research=username \
+  --bug-bounty-header User-Agent=username@wearehackerone.com
+```
+
+Equivalent JSON form:
+
+```bash
+cyber-react \
+  --target "https://example.com" \
+  --objective "Authorized bug bounty testing" \
+  --bug-bounty-headers-json '{"X-Bugcrowd":"username","User-Agent":"username@bugcrowdninja.com"}'
+```
 
 ### Configuration Loading Priority
 

--- a/docs/user-instructions.md
+++ b/docs/user-instructions.md
@@ -195,7 +195,6 @@ cyber-react \
 | `--mcp-enabled`        | `false`   | Enable MCP Tools                        |
 | `--mcp-conns` '[...]'  | None      | Configure MCP Tools                     |
 | `--bug-bounty-header NAME=VALUE` | None | Add a marker header to authorized bug bounty traffic; repeat for multiple headers |
-| `--bug-bounty-headers-json '{...}'` | None | Add marker headers from a JSON object |
 
 ### Bug Bounty Traffic Markers
 
@@ -207,15 +206,6 @@ cyber-react \
   --objective "Authorized bug bounty testing" \
   --bug-bounty-header X-HackerOne-Research=username \
   --bug-bounty-header User-Agent=username@wearehackerone.com
-```
-
-Equivalent JSON form:
-
-```bash
-cyber-react \
-  --target "https://example.com" \
-  --objective "Authorized bug bounty testing" \
-  --bug-bounty-headers-json '{"X-Bugcrowd":"username","User-Agent":"username@bugcrowdninja.com"}'
 ```
 
 ### Configuration Loading Priority

--- a/src/cyberautoagent.py
+++ b/src/cyberautoagent.py
@@ -18,6 +18,7 @@ License: MIT
 """
 
 import argparse
+import json
 import asyncio
 import atexit
 import base64
@@ -394,6 +395,23 @@ def main():
         help="Configure MCP servers, requires --mcp-enabled to be applied",
     )
     parser.add_argument(
+        "--bug-bounty-header",
+        action="append",
+        default=[],
+        metavar="NAME=VALUE",
+        help=(
+            "Add an HTTP header to mark authorized bug bounty traffic. "
+            "May be supplied multiple times, e.g. "
+            "--bug-bounty-header X-HackerOne-Research=username "
+            "--bug-bounty-header User-Agent=username@wearehackerone.com"
+        ),
+    )
+    parser.add_argument(
+        "--bug-bounty-headers-json",
+        type=str,
+        help="JSON object of HTTP headers to mark authorized bug bounty traffic",
+    )
+    parser.add_argument(
         "--heap-monitor",
         action="store_true",
         help="Monitor the heap for usage and trigger dumps when threshold exceeded",
@@ -403,6 +421,27 @@ def main():
 
     if args.heap_monitor or os.getenv("CYBER_HEAP_MONITOR", "").lower() == "true":
         from src.modules.utils import heap_monitor
+
+    bug_bounty_headers = {}
+    if args.bug_bounty_headers_json:
+        try:
+            parsed_headers = json.loads(args.bug_bounty_headers_json)
+        except json.JSONDecodeError as exc:
+            parser.error(f"--bug-bounty-headers-json must be valid JSON: {exc}")
+        if not isinstance(parsed_headers, dict) or not all(
+            isinstance(k, str) and isinstance(v, str) for k, v in parsed_headers.items()
+        ):
+            parser.error("--bug-bounty-headers-json must be a JSON object with string keys and values")
+        bug_bounty_headers.update(parsed_headers)
+
+    for header in args.bug_bounty_header:
+        if "=" not in header:
+            parser.error("--bug-bounty-header must use NAME=VALUE")
+        name, value = header.split("=", 1)
+        name = name.strip()
+        if not name:
+            parser.error("--bug-bounty-header name cannot be empty")
+        bug_bounty_headers[name] = value
 
     if args.cont or args.report:
         args.memory_mode = "auto"
@@ -696,6 +735,7 @@ def main():
             memory_path=args.memory_path,
             memory_mode=args.memory_mode,
             module=args.module,
+            bug_bounty_headers=bug_bounty_headers,
             mcp_connections=mcp_connections,
         )
         agent, callback_handler = create_agent(

--- a/src/cyberautoagent.py
+++ b/src/cyberautoagent.py
@@ -407,11 +407,6 @@ def main():
         ),
     )
     parser.add_argument(
-        "--bug-bounty-headers-json",
-        type=str,
-        help="JSON object of HTTP headers to mark authorized bug bounty traffic",
-    )
-    parser.add_argument(
         "--heap-monitor",
         action="store_true",
         help="Monitor the heap for usage and trigger dumps when threshold exceeded",
@@ -423,16 +418,18 @@ def main():
         from src.modules.utils import heap_monitor
 
     bug_bounty_headers = {}
-    if args.bug_bounty_headers_json:
-        try:
-            parsed_headers = json.loads(args.bug_bounty_headers_json)
-        except json.JSONDecodeError as exc:
-            parser.error(f"--bug-bounty-headers-json must be valid JSON: {exc}")
-        if not isinstance(parsed_headers, dict) or not all(
-            isinstance(k, str) and isinstance(v, str) for k, v in parsed_headers.items()
-        ):
-            parser.error("--bug-bounty-headers-json must be a JSON object with string keys and values")
-        bug_bounty_headers.update(parsed_headers)
+    if not args.bug_bounty_header:
+        env_headers = os.getenv("CYBER_BUG_BOUNTY_HEADERS")
+        if env_headers:
+            try:
+                parsed_headers = json.loads(env_headers)
+            except json.JSONDecodeError as exc:
+                parser.error(f"CYBER_BUG_BOUNTY_HEADERS must be valid JSON: {exc}")
+            if not isinstance(parsed_headers, dict) or not all(
+                isinstance(k, str) and isinstance(v, str) for k, v in parsed_headers.items()
+            ):
+                parser.error("CYBER_BUG_BOUNTY_HEADERS must be a JSON object with string keys and values")
+            bug_bounty_headers.update(parsed_headers)
 
     for header in args.bug_bounty_header:
         if "=" not in header:
@@ -442,6 +439,9 @@ def main():
         if not name:
             parser.error("--bug-bounty-header name cannot be empty")
         bug_bounty_headers[name] = value
+
+    if args.bug_bounty_header:
+        os.environ["CYBER_BUG_BOUNTY_HEADERS"] = json.dumps(bug_bounty_headers)
 
     if args.cont or args.report:
         args.memory_mode = "auto"

--- a/src/modules/agents/cyber_autoagent.py
+++ b/src/modules/agents/cyber_autoagent.py
@@ -460,7 +460,7 @@ Prefer MCP tools over command line tools that offer similar capabilities.
 Authorized bug bounty traffic must include these HTTP headers:
 {marker_headers}
 
-Before using browser traffic, call `browser_set_headers` with these headers. For `http_request`, command-line tools, and MCP tools that make HTTP requests, include the same headers/User-Agent in the tool input, command flags, or prompt.
+Before using browser traffic, call `browser_set_headers` with these headers. For `http_request`, command-line tools, and MCP tools that make HTTP requests, include the same headers in the tool input, command flags, or prompt.
 """
         full_tools_context = f"{full_tools_context}\n\n{marker_context}" if full_tools_context else marker_context
 

--- a/src/modules/agents/cyber_autoagent.py
+++ b/src/modules/agents/cyber_autoagent.py
@@ -450,6 +450,20 @@ Prefer MCP tools over command line tools that offer similar capabilities.
             if full_tools_context:
                 full_tools_context += "\n\n"
             full_tools_context += str(tools_ctx)
+    if config.bug_bounty_headers:
+        marker_headers = "\n".join(
+            f"- {name}: {value}" for name, value in sorted(config.bug_bounty_headers.items())
+        )
+        marker_context = f"""
+## BUG BOUNTY TRAFFIC MARKERS
+
+Authorized bug bounty traffic must include these HTTP headers:
+{marker_headers}
+
+Before using browser traffic, call `browser_set_headers` with these headers. For `http_request`, command-line tools, and MCP tools that make HTTP requests, include the same headers/User-Agent in the tool input, command flags, or prompt.
+"""
+        full_tools_context = f"{full_tools_context}\n\n{marker_context}" if full_tools_context else marker_context
+
     if full_tools_context:
         full_tools_context = f"""
 ## TOOLS
@@ -457,6 +471,18 @@ Prefer MCP tools over command line tools that offer similar capabilities.
 Prefer tools present in the following lists. If a capability is missing, follow Ask-Enable-Retry for minimal, non-interactive enablement, or choose an equivalent available tool.
 
 """ + full_tools_context
+
+    if config.bug_bounty_headers:
+        try:
+            import asyncio
+
+            asyncio.run(browser_set_headers(config.bug_bounty_headers))
+            agent_logger.info(
+                "Applied %d bug bounty marker header(s) to the browser context",
+                len(config.bug_bounty_headers),
+            )
+        except Exception as e:
+            agent_logger.warning("Unable to pre-apply bug bounty browser headers: %s", e)
 
     # Always use original tools - event emission is handled by callback
     # The following are builtin_tools that can be selected by the module

--- a/src/modules/config/types.py
+++ b/src/modules/config/types.py
@@ -286,6 +286,7 @@ class AgentConfig:
     memory_path: Optional[str] = None
     memory_mode: str = "auto"
     module: str = "web"
+    bug_bounty_headers: Dict[str, str] = field(default_factory=dict)
     mcp_connections: List[MCPConnection] = field(default_factory=list)
 
 

--- a/src/modules/interfaces/react/src/components/ConfigEditor.tsx
+++ b/src/modules/interfaces/react/src/components/ConfigEditor.tsx
@@ -177,6 +177,10 @@ const CONFIG_FIELDS: ConfigField[] = [
   { key: 'maxThreads', label: 'Max Threads', type: 'number', section: 'Operations' },
   { key: 'dockerTimeout', label: 'Docker Timeout (s)', type: 'number', section: 'Operations' },
   { key: 'verbose', label: 'Verbose Output', type: 'boolean', section: 'Operations' },
+  {
+    key: 'bugBountyHeaders', label: 'Bug Bounty Headers (JSON)', type: 'text', section: 'Operations',
+    description: 'JSON map of authorized bug bounty marker headers.'
+  },
 
   // Context Management
   {
@@ -1142,6 +1146,22 @@ export const ConfigEditor: React.FC<ConfigEditorProps> = ({ onClose }) => {
       return;
     }
 
+    if (key === 'bugBountyHeaders') {
+      try {
+        const parsed = typeof value === 'string' && value.trim()
+          ? JSON.parse(value)
+          : {};
+        if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+          throw new Error('Expected a JSON object');
+        }
+        updateConfig({ bugBountyHeaders: parsed });
+        setUnsavedChanges(true);
+      } catch (e: any) {
+        showMessage(`Invalid bug bounty headers JSON: ${e?.message || String(e)}`, 'error', 5000);
+      }
+      return;
+    }
+
     // Handle nested keys
     if (key.includes('.')) {
       const parts = key.split('.');
@@ -1213,6 +1233,8 @@ export const ConfigEditor: React.FC<ConfigEditorProps> = ({ onClose }) => {
       }
     } else if (field.type === 'number') {
       setTempValue(String(currentValue || 0));
+    } else if (field.key === 'bugBountyHeaders') {
+      setTempValue(currentValue ? JSON.stringify(currentValue) : '');
     } else {
       setTempValue(String(currentValue || ''));
     }
@@ -1239,6 +1261,12 @@ export const ConfigEditor: React.FC<ConfigEditorProps> = ({ onClose }) => {
         const status = mcpTestStatus[selectedMcpIndex];
         return status ? `Press Enter to test — ${status}` : 'Press Enter to test';
       }
+    }
+
+    if (key === 'bugBountyHeaders') {
+      return config.bugBountyHeaders && Object.keys(config.bugBountyHeaders).length > 0
+        ? JSON.stringify(config.bugBountyHeaders)
+        : '';
     }
 
     // Special handling for model pricing info

--- a/src/modules/interfaces/react/src/contexts/ConfigContext.tsx
+++ b/src/modules/interfaces/react/src/contexts/ConfigContext.tsx
@@ -167,6 +167,8 @@ export interface Config {
   outputFormat: 'markdown' | 'json' | 'html';
   /** Enable detailed debug logging and verbose output */
   verbose: boolean;
+  /** HTTP headers to mark authorized bug bounty traffic */
+  bugBountyHeaders?: Record<string, string>;
 
   // Context Management
   /** Conversation window size - max messages in history */
@@ -511,6 +513,7 @@ export const defaultConfig: Config = {
   maxThreads: 10,
   outputFormat: 'markdown',
   verbose: false, // Default to non-verbose mode
+  bugBountyHeaders: {},
 
   // Context Management
   conversationWindow: 100, // Default conversation window size (sliding window)

--- a/src/modules/interfaces/react/src/services/DirectDockerService.ts
+++ b/src/modules/interfaces/react/src/services/DirectDockerService.ts
@@ -275,6 +275,9 @@ export class DirectDockerService extends EventEmitter {
       if (config.modelId) {
         env.push(`CYBER_AGENT_LLM_MODEL=${config.modelId}`);
       }
+      if (config.bugBountyHeaders && Object.keys(config.bugBountyHeaders).length > 0) {
+        env.push(`CYBER_BUG_BOUNTY_HEADERS=${JSON.stringify(config.bugBountyHeaders)}`);
+      }
       if (config.rateLimitTokensPerMinute) {
         env.push(`CYBER_RATE_LIMIT_TOKENS_PER_MIN=${config.rateLimitTokensPerMinute}`);
       }

--- a/src/modules/interfaces/react/src/services/PythonExecutionService.ts
+++ b/src/modules/interfaces/react/src/services/PythonExecutionService.ts
@@ -738,6 +738,9 @@ export class PythonExecutionService extends EventEmitter {
         ...(config.memoryModel ? { MEM0_LLM_MODEL: config.memoryModel } : {}),
         // Model rate limits
         ...(config.rateLimitTokensPerMinute ? { CYBER_RATE_LIMIT_TOKENS_PER_MIN: String(config.rateLimitTokensPerMinute) } : {}),
+        ...(config.bugBountyHeaders && Object.keys(config.bugBountyHeaders).length > 0
+          ? { CYBER_BUG_BOUNTY_HEADERS: JSON.stringify(config.bugBountyHeaders) }
+          : {}),
         ...(config.rateLimitRequestsPerMinute ? { CYBER_RATE_LIMIT_REQ_PER_MIN: String(config.rateLimitRequestsPerMinute) } : {}),
         ...(config.rateLimitConcurrency ? { CYBER_RATE_LIMIT_MAX_CONCURRENT: String(config.rateLimitConcurrency) } : {}),
         // Context Management - conversation budget settings

--- a/tests/test_bug_bounty_headers.py
+++ b/tests/test_bug_bounty_headers.py
@@ -1,0 +1,53 @@
+import os
+import sys
+from unittest.mock import Mock, patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from modules.agents.cyber_autoagent import AgentConfig, create_agent
+
+
+@patch("modules.agents.cyber_autoagent.browser_set_headers")
+@patch("modules.config.ConfigManager.validate_requirements")
+@patch("modules.config.models.factory.create_ollama_model")
+@patch("modules.agents.cyber_autoagent.Agent")
+@patch("modules.handlers.react.react_bridge_handler.ReactBridgeHandler")
+@patch("modules.agents.cyber_autoagent.prompts.get_system_prompt")
+@patch("modules.agents.cyber_autoagent.initialize_memory_system")
+def test_bug_bounty_headers_are_applied_and_added_to_prompt(
+    mock_init_memory,
+    mock_get_prompt,
+    mock_react_bridge_handler,
+    mock_agent_class,
+    mock_create_ollama,
+    mock_validate,
+    mock_browser_set_headers,
+):
+    mock_model = Mock()
+    mock_create_ollama.return_value = mock_model
+    mock_agent = Mock()
+    mock_agent_class.return_value = mock_agent
+    mock_handler = Mock()
+    mock_react_bridge_handler.return_value = mock_handler
+    mock_get_prompt.return_value = "test prompt"
+
+    headers = {
+        "User-Agent": "researcher@wearehackerone.com",
+        "X-HackerOne-Research": "researcher",
+    }
+
+    config = AgentConfig(
+        target="example.com",
+        objective="authorized test",
+        provider="ollama",
+        bug_bounty_headers=headers,
+    )
+    create_agent(target="example.com", objective="authorized test", config=config)
+
+    mock_browser_set_headers.assert_called_once_with(headers)
+    prompt_kwargs = mock_get_prompt.call_args.kwargs
+    tools_context = prompt_kwargs["tools_context"]
+    assert "BUG BOUNTY TRAFFIC MARKERS" in tools_context
+    assert "X-HackerOne-Research: researcher" in tools_context
+    assert "User-Agent: researcher@wearehackerone.com" in tools_context
+    assert "MCP tools" in tools_context

--- a/tests/test_bug_bounty_headers_env.py
+++ b/tests/test_bug_bounty_headers_env.py
@@ -1,0 +1,49 @@
+import argparse
+import json
+import os
+from unittest.mock import Mock
+
+
+def parse_bug_bounty_headers(args):
+    bug_bounty_headers = {}
+    if not args.bug_bounty_header:
+        env_headers = os.getenv("CYBER_BUG_BOUNTY_HEADERS")
+        if env_headers:
+            parsed_headers = json.loads(env_headers)
+            if not isinstance(parsed_headers, dict) or not all(
+                isinstance(k, str) and isinstance(v, str) for k, v in parsed_headers.items()
+            ):
+                raise argparse.ArgumentTypeError(
+                    "CYBER_BUG_BOUNTY_HEADERS must be a JSON object with string keys and values"
+                )
+            bug_bounty_headers.update(parsed_headers)
+
+    for header in args.bug_bounty_header:
+        if "=" not in header:
+            raise argparse.ArgumentTypeError("--bug-bounty-header must use NAME=VALUE")
+        name, value = header.split("=", 1)
+        name = name.strip()
+        if not name:
+            raise argparse.ArgumentTypeError("--bug-bounty-header name cannot be empty")
+        bug_bounty_headers[name] = value
+
+    if args.bug_bounty_header:
+        os.environ["CYBER_BUG_BOUNTY_HEADERS"] = json.dumps(bug_bounty_headers)
+    return bug_bounty_headers
+
+
+def test_bug_bounty_headers_read_from_environment_when_cli_headers_absent(monkeypatch):
+    monkeypatch.setenv("CYBER_BUG_BOUNTY_HEADERS", '{"X-HackerOne-Research":"researcher"}')
+
+    headers = parse_bug_bounty_headers(Mock(bug_bounty_header=[]))
+
+    assert headers == {"X-HackerOne-Research": "researcher"}
+
+
+def test_cli_bug_bounty_headers_override_environment_and_update_env(monkeypatch):
+    monkeypatch.setenv("CYBER_BUG_BOUNTY_HEADERS", '{"X-Research":"env"}')
+
+    headers = parse_bug_bounty_headers(Mock(bug_bounty_header=["X-Research=cli"]))
+
+    assert headers == {"X-Research": "cli"}
+    assert os.environ["CYBER_BUG_BOUNTY_HEADERS"] == '{"X-Research": "cli"}'


### PR DESCRIPTION
Fixes #63.\n\nAdds configurable bug bounty marker support for HTTP headers/User-Agent and includes those markers in agent context for external/MCP tools.\n\nVerification:\n- `PYTHONPATH=src uv run --python 3.11 pytest -q tests/test_bug_bounty_headers.py` ✅